### PR TITLE
fix: Add missing precision rounding for debit_in_account_currency

### DIFF
--- a/erpnext_france/utils/accounting_entry_number.py
+++ b/erpnext_france/utils/accounting_entry_number.py
@@ -36,10 +36,13 @@ def add_accounting_entry_number(gl_entry, action):
 	gl_entry.accounting_entry_number = accounting_entry_number
 	gl_entry.accounting_journal = get_accounting_journal(gl_entry)
 
+	# Fix precision issues for all currency fields
 	gl_entry.credit_in_account_currency = round(
 		gl_entry.credit_in_account_currency,
-		gl_entry.precision('credit_in_account_currency'
-    ))
+		gl_entry.precision('credit_in_account_currency'))
+	gl_entry.debit_in_account_currency = round(
+		gl_entry.debit_in_account_currency,
+		gl_entry.precision('debit_in_account_currency'))
 	gl_entry.save()
 
 

--- a/erpnext_france/utils/accounting_entry_number.py
+++ b/erpnext_france/utils/accounting_entry_number.py
@@ -43,6 +43,12 @@ def add_accounting_entry_number(gl_entry, action):
 	gl_entry.debit_in_account_currency = round(
 		gl_entry.debit_in_account_currency,
 		gl_entry.precision('debit_in_account_currency'))
+	gl_entry.credit = round(
+		gl_entry.credit,
+		gl_entry.precision('credit'))
+	gl_entry.debit = round(
+		gl_entry.debit,
+		gl_entry.precision('debit'))
 	gl_entry.save()
 
 


### PR DESCRIPTION
Fixes #5

Fixes UpdateAfterSubmitError when Payment Entries have floating point precision issues.

## Problem
The code was only rounding `credit_in_account_currency` but not other currency fields, causing errors during both submission and cancellation operations:

Submission error:
> Not allowed to change Montant Débiteur en Devise du Compte after submission from 443.53 to 443.5300000000001

Cancellation error:  
> Not allowed to change Montant du Crédit after submission from 452.49 to 452.49000000000007

## Solution  
This fix ensures all currency fields are properly rounded to their defined precision before saving GL Entries:

- `credit_in_account_currency`
- `debit_in_account_currency`  
- `credit`
- `debit`

## Testing
- Tested Payment Entry submission with amount 443.53
- Tested Payment Entry cancellation with amount 452.49  
- No more UpdateAfterSubmitError on GL Entry operations
- All currency amounts properly rounded to configured precision