### PR TITLE
fix(sepa): ensure bordereau uses company bank account only

### DIFF
--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -1,42 +1,68 @@
 // Copyright (c) 2026, Scopen and contributors
 // For license information, please see license.txt
 
+function company_bank_account_filters(company) {
+	return {
+		company: company,
+		is_company_account: 1
+	};
+}
+
 function set_default_bank_account(frm) {
-	if (frm.doc.company && !frm.doc.bank_account) {
-		frappe.db.get_value('Company', frm.doc.company, 'default_bank_account', function(company) {
-			if (company && company.default_bank_account) {
-				frappe.db.get_value('Bank Account',
-					{'company': frm.doc.company, 'account': company.default_bank_account},
-					'name',
-					function(r) {
-						if (r && r.name) {
-							frm.set_value('bank_account', r.name);
-						} else {
-							frappe.db.get_value('Bank Account',
-								{'company': frm.doc.company, 'is_default': 1},
-								'name',
-								function(fallback) {
-									if (fallback && fallback.name) {
-										frm.set_value('bank_account', fallback.name);
-									}
-								}
-							);
-						}
-					}
-				);
-			} else {
-				frappe.db.get_value('Bank Account',
-					{'company': frm.doc.company, 'is_default': 1},
-					'name',
-					function(r) {
-						if (r && r.name) {
-							frm.set_value('bank_account', r.name);
-						}
-					}
-				);
-			}
-		});
+	if (!frm.doc.company || frm.doc.bank_account) {
+		return;
 	}
+
+	frappe.db.get_value('Company', frm.doc.company, 'default_bank_account', function(company) {
+		const filters = company_bank_account_filters(frm.doc.company);
+
+		if (company && company.default_bank_account) {
+			frappe.db.get_value(
+				'Bank Account',
+				{ ...filters, account: company.default_bank_account },
+				'name',
+				function(r) {
+					if (r && r.name) {
+						frm.set_value('bank_account', r.name);
+					} else {
+						set_fallback_company_bank_account(frm, filters);
+					}
+				}
+			);
+		} else {
+			set_fallback_company_bank_account(frm, filters);
+		}
+	});
+}
+
+function set_fallback_company_bank_account(frm, filters) {
+	frappe.db.get_value(
+		'Bank Account',
+		{ ...filters, is_default: 1 },
+		'name',
+		function(r) {
+			if (r && r.name) {
+				frm.set_value('bank_account', r.name);
+			}
+		}
+	);
+}
+
+function ensure_company_bank_account(frm) {
+	if (!frm.doc.bank_account || !frm.doc.company) {
+		return;
+	}
+
+	frappe.db.get_value('Bank Account', frm.doc.bank_account, 'is_company_account', function(r) {
+		if (r && !r.is_company_account) {
+			frm.set_value('bank_account', null);
+			set_default_bank_account(frm);
+			frappe.show_alert({
+				message: __('Customer/supplier bank account replaced with company bank account'),
+				indicator: 'orange'
+			});
+		}
+	});
 }
 
 frappe.ui.form.on('SEPA Payment Bordereau', {
@@ -111,25 +137,30 @@ frappe.ui.form.on('SEPA Payment Bordereau', {
 	},
 
 	onload: function(frm) {
-		// Set query for bank account to only show company's bank accounts
-		if (frm.doc.company) {
-			frm.set_query('bank_account', function() {
-				return {
-					filters: {
-						'company': frm.doc.company,
-						'is_company_account': 1
-					}
-				};
-			});
+		frm.trigger('setup_bank_account_query');
+		if (frm.doc.bank_account) {
+			ensure_company_bank_account(frm);
+		} else {
+			set_default_bank_account(frm);
 		}
-
-		// Ensure default bank account is set on new bordereau
-		set_default_bank_account(frm);
 	},
 
 	company: function(frm) {
-		// Set default bank account when company changes
+		frm.set_value('bank_account', null);
+		frm.trigger('setup_bank_account_query');
 		set_default_bank_account(frm);
+	},
+
+	setup_bank_account_query: function(frm) {
+		if (!frm.doc.company) {
+			return;
+		}
+
+		frm.set_query('bank_account', function() {
+			return {
+				filters: company_bank_account_filters(frm.doc.company)
+			};
+		});
 	}
 });
 

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -19,7 +19,22 @@ class SEPAPaymentBordereau(Document):
 
 	def validate(self):
 		self.calculate_total()
+		self.validate_company_bank_account()
 		self.validate_lines()
+
+	def validate_company_bank_account(self):
+		"""Bank account on the bordereau must be a company account, not a customer/supplier one."""
+		if not self.bank_account or not self.company:
+			return
+
+		from erpnext_france.regional.france.sepa_utils import is_company_bank_account
+
+		if not is_company_bank_account(self.bank_account, self.company):
+			frappe.throw(
+				_("Bank Account {0} is not a company bank account. Please select your company's bank account.").format(
+					self.bank_account
+				)
+			)
 
 	def on_update(self):
 		status_changed_lines = False
@@ -82,6 +97,8 @@ class SEPAPaymentBordereau(Document):
 		# Check Company bank account
 		if not self.bank_account:
 			frappe.throw(_("Please select a bank account for the bordereau"))
+
+		self.validate_company_bank_account()
 
 		bank_account = frappe.get_doc("Bank Account", self.bank_account)
 		if not bank_account.iban:

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -109,6 +109,54 @@ def validate_invoice_for_sepa(invoice, invoice_type):
 			frappe.throw(_("Supplier {0} does not have a default bank account").format(invoice.supplier))
 
 
+def is_company_bank_account(bank_account, company):
+	"""Return whether the Bank Account belongs to the company itself."""
+	return bool(
+		bank_account
+		and frappe.db.exists(
+			"Bank Account",
+			{
+				"name": bank_account,
+				"company": company,
+				"is_company_account": 1
+			}
+		)
+	)
+
+
+def get_default_company_bank_account(company):
+	"""Get the default company-owned Bank Account for a company."""
+	company_default_account = frappe.db.get_value("Company", company, "default_bank_account")
+	default_bank_account = None
+
+	if company_default_account:
+		default_bank_account = frappe.db.get_value(
+			"Bank Account",
+			{
+				"company": company,
+				"account": company_default_account,
+				"is_company_account": 1
+			},
+			"name"
+		)
+
+	if not default_bank_account:
+		default_bank_account = frappe.db.get_value(
+			"Bank Account",
+			{
+				"company": company,
+				"is_default": 1,
+				"is_company_account": 1
+			},
+			"name"
+		)
+
+	if not default_bank_account:
+		frappe.throw(_("No default company bank account found for company {0}").format(company))
+
+	return default_bank_account
+
+
 def get_or_create_bordereau(payment_type, company):
 	"""Get existing draft bordereau or create new one"""
 
@@ -124,35 +172,16 @@ def get_or_create_bordereau(payment_type, company):
 	)
 
 	if existing:
-		return frappe.get_doc("SEPA Payment Bordereau", existing)
+		bordereau = frappe.get_doc("SEPA Payment Bordereau", existing)
+		if not is_company_bank_account(bordereau.bank_account, company):
+			bordereau.bank_account = get_default_company_bank_account(company)
+			bordereau.save()
+		return bordereau
 
 	# Create new bordereau
 	from datetime import datetime, timedelta
 
-	# Get default company bank account (prefer company's default bank account GL)
-	company_default_account = frappe.db.get_value("Company", company, "default_bank_account")
-	default_bank_account = None
-	if company_default_account:
-		default_bank_account = frappe.db.get_value(
-			"Bank Account",
-			{
-				"company": company,
-				"account": company_default_account
-			},
-			"name"
-		)
-	if not default_bank_account:
-		default_bank_account = frappe.db.get_value(
-			"Bank Account",
-			{
-				"company": company,
-				"is_default": 1
-			},
-			"name"
-		)
-
-	if not default_bank_account:
-		frappe.throw(_("No default bank account found for company {0}").format(company))
+	default_bank_account = get_default_company_bank_account(company)
 
 	bordereau = frappe.get_doc({
 		"doctype": "SEPA Payment Bordereau",


### PR DESCRIPTION
Filter default bank account lookup by is_company_account, correct reused draft bordereaux, and validate on save and in the form UI.