### PR TITLE
feat: allow manual SEPA bordereau lines without an invoice

### DIFF
--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -208,10 +208,11 @@ function lock_manual_lines(frm) {
       return;
     }
 
-    const locked = Boolean(line.payment_entry);
+    const locked = is_line_locked(line);
     data_fields.forEach((fieldname) => {
       set_grid_field_read_only(grid_row, fieldname, locked);
     });
+    set_grid_field_read_only(grid_row, "status", is_status_locked(line));
 
     if (grid_row.wrapper) {
       grid_row.wrapper
@@ -302,9 +303,9 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
 
     // Accept selected pending lines after bank execution
     if (["Sent", "Partial Rejections", "Exported"].includes(frm.doc.status)) {
-      const has_pending_lines = (frm.doc.lines || []).some(
-        (line) => line.status === "Pending"
-      );
+      const has_pending_lines =
+        (frm.doc.lines || []).some((line) => line.status === "Pending") ||
+        (frm.doc.manual_lines || []).some((line) => line.status === "Pending");
       if (has_pending_lines) {
         frm.add_custom_button(
           __("Accept Selection"),
@@ -313,20 +314,6 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
           },
           __("Actions")
         );
-      }
-
-      if (!has_pending_lines) {
-        frm.add_custom_button(__("Close Bordereau"), function () {
-          frappe.call({
-            method: "close_bordereau",
-            doc: frm.doc,
-            freeze: true,
-            freeze_message: __("Closing bordereau..."),
-            callback: function () {
-              frm.reload_doc();
-            },
-          });
-        });
       }
     }
 
@@ -364,6 +351,7 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
   manual_lines_add: function (frm, cdt, cdn) {
     const { party_type } = get_line_types(frm.doc.payment_type);
     frappe.model.set_value(cdt, cdn, "party_type", party_type);
+    frappe.model.set_value(cdt, cdn, "status", "Pending");
   },
 
   calculate_total: function (frm) {
@@ -455,7 +443,11 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
 });
 
 function get_selected_grid_rows(frm, fieldname) {
-  const grid = frm.fields_dict[fieldname].grid;
+  const field = frm.fields_dict[fieldname];
+  if (!field || !field.grid) {
+    return [];
+  }
+  const grid = field.grid;
   if (grid.get_selected_children) {
     return grid.get_selected_children();
   }
@@ -469,8 +461,10 @@ function get_selected_grid_rows(frm, fieldname) {
 }
 
 function accept_selected_lines(frm) {
-  const selected = get_selected_grid_rows(frm, "lines");
-  const pending = selected.filter((line) => line.status === "Pending");
+  const pending = [
+    ...get_selected_grid_rows(frm, "lines"),
+    ...get_selected_grid_rows(frm, "manual_lines"),
+  ].filter((line) => line.status === "Pending");
 
   if (!pending.length) {
     frappe.msgprint(__("Please select at least one pending line"));

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -495,6 +495,11 @@ function show_accept_results(results) {
 
   if (results.success.length) {
     parts.push(`<b>${__("Accepted")}:</b> ${results.success.length}`);
+    results.success.forEach((row) => {
+      if (row.payment_entry) {
+        parts.push(`${row.invoice}: ${row.payment_entry}`);
+      }
+    });
   }
   if (results.skipped.length) {
     parts.push(`<b>${__("Skipped")}:</b> ${results.skipped.length}`);

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -495,11 +495,6 @@ function show_accept_results(results) {
 
   if (results.success.length) {
     parts.push(`<b>${__("Accepted")}:</b> ${results.success.length}`);
-    results.success.forEach((row) => {
-      if (row.payment_entry) {
-        parts.push(`${row.invoice}: ${row.payment_entry}`);
-      }
-    });
   }
   if (results.skipped.length) {
     parts.push(`<b>${__("Skipped")}:</b> ${results.skipped.length}`);

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -190,6 +190,37 @@ function lock_processed_lines(frm) {
   });
 }
 
+function lock_manual_lines(frm) {
+  const grid = frm.fields_dict.manual_lines && frm.fields_dict.manual_lines.grid;
+  if (!grid) {
+    return;
+  }
+
+  const data_fields = ["document_ref", "party", "amount", "mandate"];
+
+  (frm.doc.manual_lines || []).forEach((line) => {
+    if (!line.name) {
+      return;
+    }
+
+    const grid_row = grid.grid_rows_by_docname[line.name];
+    if (!grid_row) {
+      return;
+    }
+
+    const locked = Boolean(line.payment_entry);
+    data_fields.forEach((fieldname) => {
+      set_grid_field_read_only(grid_row, fieldname, locked);
+    });
+
+    if (grid_row.wrapper) {
+      grid_row.wrapper
+        .find(".grid-delete-row, .grid-duplicate-row")
+        .toggle(!locked);
+    }
+  });
+}
+
 function sync_line_types(frm, cdt, cdn) {
   const { invoice_type, party_type } = get_line_types(frm.doc.payment_type);
   frappe.model.set_value(cdt, cdn, "invoice_type", invoice_type);
@@ -203,15 +234,18 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
     }
 
     lock_processed_lines(frm);
+    lock_manual_lines(frm);
     // Grid rows may finish rendering after refresh
-    setTimeout(() => lock_processed_lines(frm), 200);
+    setTimeout(() => {
+      lock_processed_lines(frm);
+      lock_manual_lines(frm);
+    }, 200);
 
     // Add Validate button
-    if (
-      frm.doc.status === "Draft" &&
-      frm.doc.lines &&
-      frm.doc.lines.length > 0
-    ) {
+    const has_lines =
+      (frm.doc.lines && frm.doc.lines.length > 0) ||
+      (frm.doc.manual_lines && frm.doc.manual_lines.length > 0);
+    if (frm.doc.status === "Draft" && has_lines) {
       frm
         .add_custom_button(__("Validate Bordereau"), function () {
           frappe.call({
@@ -280,6 +314,20 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
           __("Actions")
         );
       }
+
+      if (!has_pending_lines) {
+        frm.add_custom_button(__("Close Bordereau"), function () {
+          frappe.call({
+            method: "close_bordereau",
+            doc: frm.doc,
+            freeze: true,
+            freeze_message: __("Closing bordereau..."),
+            callback: function () {
+              frm.reload_doc();
+            },
+          });
+        });
+      }
     }
 
     // Set color indicator based on status
@@ -299,10 +347,42 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
   payment_type: function (frm) {
     frm.trigger("set_naming");
     frm.trigger("setup_line_queries");
+    const { party_type } = get_line_types(frm.doc.payment_type);
+    (frm.doc.manual_lines || []).forEach((line) => {
+      if (line.party_type !== party_type) {
+        frappe.model.set_value(line.doctype, line.name, "party_type", party_type);
+        frappe.model.set_value(line.doctype, line.name, "party", null);
+        frappe.model.set_value(line.doctype, line.name, "mandate", null);
+      }
+    });
   },
 
   lines_add: function (frm, cdt, cdn) {
     sync_line_types(frm, cdt, cdn);
+  },
+
+  manual_lines_add: function (frm, cdt, cdn) {
+    const { party_type } = get_line_types(frm.doc.payment_type);
+    frappe.model.set_value(cdt, cdn, "party_type", party_type);
+  },
+
+  calculate_total: function (frm) {
+    let total = 0;
+    (frm.doc.lines || []).forEach((line) => {
+      total += flt(line.amount);
+    });
+    (frm.doc.manual_lines || []).forEach((line) => {
+      total += flt(line.amount);
+    });
+    frm.set_value("total_amount", total);
+  },
+
+  manual_lines_remove: function (frm) {
+    frm.trigger("calculate_total");
+  },
+
+  lines_remove: function (frm) {
+    frm.trigger("calculate_total");
   },
 
   onload: function (frm) {
@@ -362,6 +442,12 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
     frm.set_query("party", "lines", function (doc, cdt, cdn) {
       const row = locals[cdt][cdn];
       row.invoice_type = invoice_type;
+      row.party_type = party_type;
+      return {};
+    });
+
+    frm.set_query("party", "manual_lines", function (doc, cdt, cdn) {
+      const row = locals[cdt][cdn];
       row.party_type = party_type;
       return {};
     });
@@ -499,6 +585,26 @@ frappe.ui.form.on("SEPA Payment Bordereau Line", {
   },
 
   lines_remove: function (frm) {
+    frm.trigger("calculate_total");
+  },
+});
+
+frappe.ui.form.on("SEPA Payment Bordereau Manual Line", {
+  party: function (frm, cdt, cdn) {
+    const row = locals[cdt][cdn];
+    const { party_type } = get_line_types(frm.doc.payment_type);
+    frappe.model.set_value(cdt, cdn, "party_type", party_type);
+
+    if (frm.doc.payment_type === "Debit" && row.party) {
+      frappe.db.get_value("Customer", row.party, "sepa_mandate", (customer) => {
+        if (customer && customer.sepa_mandate) {
+          frappe.model.set_value(cdt, cdn, "mandate", customer.sepa_mandate);
+        }
+      });
+    }
+  },
+
+  amount: function (frm) {
     frm.trigger("calculate_total");
   },
 });

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.js
@@ -236,6 +236,7 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
 
     lock_processed_lines(frm);
     lock_manual_lines(frm);
+    frm.trigger("toggle_manual_lines");
     // Grid rows may finish rendering after refresh
     setTimeout(() => {
       lock_processed_lines(frm);
@@ -334,6 +335,15 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
   payment_type: function (frm) {
     frm.trigger("set_naming");
     frm.trigger("setup_line_queries");
+    frm.trigger("toggle_manual_lines");
+    if (frm.doc.payment_type !== "Credit") {
+      if ((frm.doc.manual_lines || []).length) {
+        frm.clear_table("manual_lines");
+        frm.refresh_field("manual_lines");
+        frm.trigger("calculate_total");
+      }
+      return;
+    }
     const { party_type } = get_line_types(frm.doc.payment_type);
     (frm.doc.manual_lines || []).forEach((line) => {
       if (line.party_type !== party_type) {
@@ -342,6 +352,12 @@ frappe.ui.form.on("SEPA Payment Bordereau", {
         frappe.model.set_value(line.doctype, line.name, "mandate", null);
       }
     });
+  },
+
+  toggle_manual_lines: function (frm) {
+    const show = frm.doc.payment_type === "Credit";
+    frm.toggle_display("section_manual_lines", show);
+    frm.toggle_display("manual_lines", show);
   },
 
   lines_add: function (frm, cdt, cdn) {

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
@@ -97,11 +97,13 @@
    "label": "Payment Lines"
   },
   {
+   "depends_on": "eval:doc.payment_type=='Credit'",
    "fieldname": "section_manual_lines",
    "fieldtype": "Section Break",
    "label": "Manual Payment Lines"
   },
   {
+   "depends_on": "eval:doc.payment_type=='Credit'",
    "fieldname": "manual_lines",
    "fieldtype": "Table",
    "label": "Manual Payment Lines",
@@ -117,7 +119,7 @@
   }
  ],
  "links": [],
- "modified": "2026-08-26 15:25:00.000000",
+ "modified": "2026-09-02 16:30:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
@@ -116,14 +116,8 @@
    "fieldtype": "Column Break"
   }
  ],
- "links": [
-  {
-   "group": "Payments",
-   "link_doctype": "Payment Entry",
-   "link_fieldname": "sepa_payment_bordereau"
-  }
- ],
- "modified": "2026-08-26 12:40:00.000000",
+ "links": [],
+ "modified": "2026-08-26 15:25:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
@@ -116,8 +116,14 @@
    "fieldtype": "Column Break"
   }
  ],
- "links": [],
- "modified": "2026-08-26 10:00:00.000000",
+ "links": [
+  {
+   "group": "Payments",
+   "link_doctype": "Payment Entry",
+   "link_fieldname": "sepa_payment_bordereau"
+  }
+ ],
+ "modified": "2026-08-26 12:40:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.json
@@ -15,6 +15,8 @@
   "status",
   "section_break_2",
   "lines",
+  "section_manual_lines",
+  "manual_lines",
   "section_break_3",
   "total_amount",
   "column_break_4",
@@ -95,6 +97,17 @@
    "label": "Payment Lines"
   },
   {
+   "fieldname": "section_manual_lines",
+   "fieldtype": "Section Break",
+   "label": "Manual Payment Lines"
+  },
+  {
+   "fieldname": "manual_lines",
+   "fieldtype": "Table",
+   "label": "Manual Payment Lines",
+   "options": "SEPA Payment Bordereau Manual Line"
+  },
+  {
    "fieldname": "section_break_3",
    "fieldtype": "Section Break"
   },
@@ -104,7 +117,7 @@
   }
  ],
  "links": [],
- "modified": "2026-01-15 00:00:00.000000",
+ "modified": "2026-08-26 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -65,11 +65,10 @@ class SEPAPaymentBordereau(Document):
 	def on_update(self):
 		status_changed_lines = False
 		invoices_to_sync = {(line.invoice, line.invoice_type) for line in self.lines if line.invoice}
+		old_doc = None if self.is_new() else self.get_doc_before_save()
 
-		if not self.is_new() and self.get_doc_before_save():
-			old_doc = self.get_doc_before_save()
+		if old_doc:
 			old_statuses = {d.name: d.status for d in old_doc.lines}
-			old_manual_statuses = {d.name: d.status for d in (old_doc.get("manual_lines") or [])}
 			invoices_to_sync.update(
 				(line.invoice, line.invoice_type) for line in old_doc.lines if line.invoice
 			)
@@ -81,17 +80,25 @@ class SEPAPaymentBordereau(Document):
 					reconcile_sepa_line_on_status_change(self, line, line.status)
 					status_changed_lines = True
 
-			for line in self.get_manual_lines():
-				old_status = old_manual_statuses.get(line.name)
-				if line.status != old_status and line.status in ["Accepted", "Rejected"]:
-					from erpnext_france.regional.france.sepa_utils import (
-						reconcile_sepa_manual_line_on_status_change,
-					)
+		from erpnext_france.regional.france.sepa_utils import (
+			reconcile_sepa_manual_line_on_status_change,
+			sync_invoices_sepa_bordereau_links,
+		)
 
-					reconcile_sepa_manual_line_on_status_change(self, line, line.status)
-					status_changed_lines = True
+		old_manual_statuses = {}
+		if old_doc:
+			old_manual_statuses = {d.name: d.status for d in (old_doc.get("manual_lines") or [])}
 
-		from erpnext_france.regional.france.sepa_utils import sync_invoices_sepa_bordereau_links
+		# Create missing Payment Entries for Accepted/Rejected manual lines, even if
+		# the status change was not detected (grid edit, catch-up after a failed save).
+		for line in self.get_manual_lines():
+			if line.status not in ("Accepted", "Rejected"):
+				continue
+			old_status = old_manual_statuses.get(line.name)
+			if line.status == old_status and self._manual_line_has_submitted_payment_entry(line):
+				continue
+			reconcile_sepa_manual_line_on_status_change(self, line, line.status)
+			status_changed_lines = True
 
 		sync_invoices_sepa_bordereau_links(invoices_to_sync)
 
@@ -110,6 +117,13 @@ class SEPAPaymentBordereau(Document):
 
 			if new_status != self.status:
 				self.db_set("status", new_status)
+
+	@staticmethod
+	def _manual_line_has_submitted_payment_entry(line):
+		payment_entry = line.get("payment_entry")
+		if not payment_entry:
+			return False
+		return frappe.db.get_value("Payment Entry", payment_entry, "docstatus") == 1
 
 	def get_manual_lines(self):
 		return self.get("manual_lines") or []
@@ -866,7 +880,13 @@ class SEPAPaymentBordereau(Document):
 					"Accepted",
 					update_modified=False,
 				)
-				results["success"].append({"name": line.name, "invoice": label})
+				results["success"].append(
+					{
+						"name": line.name,
+						"invoice": label,
+						"payment_entry": line.payment_entry,
+					}
+				)
 			except Exception as e:
 				frappe.db.rollback(save_point=savepoint)
 				results["failed"].append({"name": line.name, "invoice": label, "reason": str(e)})

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -239,8 +239,13 @@ class SEPAPaymentBordereau(Document):
 					frappe.throw(_("Row {0}: Amount must be greater than zero").format(line.idx))
 
 	def validate_manual_lines(self):
-		"""Validate manual / advance lines (no invoice)."""
-		expected_party_type = "Supplier" if self.payment_type == "Credit" else "Customer"
+		"""Validate manual / advance lines (no invoice). Credit (transfer) only."""
+		if self.payment_type != "Credit":
+			if self.status == "Draft" and self.get_manual_lines():
+				self.set("manual_lines", [])
+			return
+
+		expected_party_type = "Supplier"
 
 		for line in self.get_manual_lines():
 			line.party_type = expected_party_type
@@ -251,10 +256,7 @@ class SEPAPaymentBordereau(Document):
 			if not line.document_ref:
 				frappe.throw(_("Manual row {0}: Document Reference is required").format(line.idx))
 
-			if self.payment_type == "Debit" and line.party and not line.mandate:
-				line.mandate = frappe.db.get_value("Customer", line.party, "sepa_mandate")
-
-			if self.payment_type == "Credit" and line.party:
+			if line.party:
 				supplier_bank_account = frappe.db.exists(
 					"Bank Account",
 					{"party_type": "Supplier", "party": line.party, "is_default": 1},
@@ -267,10 +269,6 @@ class SEPAPaymentBordereau(Document):
 					)
 
 			if self.status != "Draft":
-				if self.payment_type == "Debit" and not line.mandate:
-					frappe.throw(
-						_("Manual row {0}: SEPA Mandate is required for debit payments").format(line.idx)
-					)
 				if not line.amount or line.amount <= 0:
 					frappe.throw(_("Manual row {0}: Amount must be greater than zero").format(line.idx))
 

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -23,6 +23,7 @@ class SEPAPaymentBordereau(Document):
 		self.validate_company_bank_account()
 		self.validate_locked_lines()
 		self.validate_lines()
+		self.validate_manual_lines()
 
 	@staticmethod
 	def is_line_locked(line):
@@ -97,10 +98,21 @@ class SEPAPaymentBordereau(Document):
 			if new_status != self.status:
 				self.db_set("status", new_status)
 
+		if self.status == "Closed":
+			self.create_manual_line_payment_entries()
+
+	def get_manual_lines(self):
+		return self.get("manual_lines") or []
+
+	def get_sepa_transaction_count(self):
+		return len(self.lines or []) + len(self.get_manual_lines())
+
 	def calculate_total(self):
-		"""Calculate total amount from all lines"""
+		"""Calculate total amount from invoice lines and manual lines"""
 		total = 0
-		for line in self.lines:
+		for line in self.lines or []:
+			total += flt(line.amount)
+		for line in self.get_manual_lines():
 			total += flt(line.amount)
 		self.total_amount = total
 
@@ -216,6 +228,42 @@ class SEPAPaymentBordereau(Document):
 				if not line.amount or line.amount <= 0:
 					frappe.throw(_("Row {0}: Amount must be greater than zero").format(line.idx))
 
+	def validate_manual_lines(self):
+		"""Validate manual / advance lines (no invoice)."""
+		expected_party_type = "Supplier" if self.payment_type == "Credit" else "Customer"
+
+		for line in self.get_manual_lines():
+			line.party_type = expected_party_type
+
+			if not line.party:
+				frappe.throw(_("Manual row {0}: Party is required").format(line.idx))
+
+			if not line.document_ref:
+				frappe.throw(_("Manual row {0}: Document Reference is required").format(line.idx))
+
+			if self.payment_type == "Debit" and line.party and not line.mandate:
+				line.mandate = frappe.db.get_value("Customer", line.party, "sepa_mandate")
+
+			if self.payment_type == "Credit" and line.party:
+				supplier_bank_account = frappe.db.exists(
+					"Bank Account",
+					{"party_type": "Supplier", "party": line.party, "is_default": 1},
+				)
+				if not supplier_bank_account:
+					frappe.throw(
+						_("Manual row {0}: Supplier {1} does not have a default bank account").format(
+							line.idx, line.party
+						)
+					)
+
+			if self.status != "Draft":
+				if self.payment_type == "Debit" and not line.mandate:
+					frappe.throw(
+						_("Manual row {0}: SEPA Mandate is required for debit payments").format(line.idx)
+					)
+				if not line.amount or line.amount <= 0:
+					frappe.throw(_("Manual row {0}: Amount must be greater than zero").format(line.idx))
+
 	def sync_line_from_payment_type(self, line):
 		"""Keep line party/invoice types aligned with bordereau payment type."""
 		from erpnext_france.regional.france.sepa_utils import get_invoice_sepa_available_amount
@@ -319,6 +367,9 @@ class SEPAPaymentBordereau(Document):
 					_("Please set the SEPA Creditor Identifier (ICS) on company {0}").format(self.company)
 				)
 
+		if not (self.lines or self.get_manual_lines()):
+			frappe.throw(_("Please add at least one payment line"))
+
 		# Perform all validations
 		for line in self.lines:
 			# Check IBAN/BIC
@@ -335,26 +386,42 @@ class SEPAPaymentBordereau(Document):
 			if not line.amount or line.amount <= 0:
 				frappe.throw(_("Row {0}: Amount must be greater than zero").format(line.idx))
 
+		for line in self.get_manual_lines():
+			if self.payment_type == "Debit":
+				if not line.mandate:
+					frappe.throw(
+						_("Manual row {0}: SEPA Mandate is required for debit payments").format(line.idx)
+					)
+				mandate = frappe.get_doc("SEPA Mandate", line.mandate)
+				if mandate.status != "Active":
+					frappe.throw(_("Manual row {0}: SEPA Mandate must be active").format(line.idx))
+			if not line.amount or line.amount <= 0:
+				frappe.throw(_("Manual row {0}: Amount must be greater than zero").format(line.idx))
+
 		# Update status
 		self.status = "Validated"
 		self.save()
 		frappe.msgprint(_("Bordereau validated successfully"))
 
+	def _new_end_to_end_id(self):
+		# Format: COMPANY-YYYYMMDD-UUID (max 35 chars for SEPA)
+		timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+		unique_id = str(uuid.uuid4())[:8].upper()
+		return f"{self.company[:10]}-{timestamp}-{unique_id}"
+
 	def generate_end_to_end_ids(self):
-		"""Generate unique End-to-End IDs for all lines"""
-		for line in self.lines:
+		"""Generate unique End-to-End IDs for invoice and manual lines"""
+		for line in list(self.lines or []) + list(self.get_manual_lines()):
 			if not line.end_to_end_id:
-				# Generate unique End-to-End ID
-				# Format: COMPANY-YYYYMMDD-UUID (max 35 chars for SEPA)
-				timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-				unique_id = str(uuid.uuid4())[:8].upper()
-				line.end_to_end_id = f"{self.company[:10]}-{timestamp}-{unique_id}"
+				line.end_to_end_id = self._new_end_to_end_id()
 
 	@frappe.whitelist()
 	def generate_sepa_file(self):
 		"""Generate SEPA XML file (pain.008 for debit, pain.001 for credit)"""
 		if self.status not in ["Validated", "Exported"]:
 			frappe.throw(_("Bordereau must be validated before generating SEPA file"))
+
+		self.generate_end_to_end_ids()
 
 		if self.payment_type == "Debit":
 			xml_content = self.generate_pain_008()
@@ -393,14 +460,8 @@ class SEPAPaymentBordereau(Document):
 				_("Please set the SEPA Creditor Identifier (ICS) on company {0}").format(self.company)
 			)
 
-		# Group lines by (mandate_type, sequence_type) — pain.008 requires one PmtInf per SeqTp
-		groups = {}
-		for line in self.lines:
-			mandate = frappe.get_doc("SEPA Mandate", line.mandate)
-			key = (mandate.mandate_type, mandate.sequence_type)
-			if key not in groups:
-				groups[key] = []
-			groups[key].append((line, mandate))
+		# Invoice groups first, then manual lines at the end of the file
+		ordered_groups = self._ordered_pain_008_groups()
 
 		nsmap = {
 			None: "urn:iso:std:iso:20022:tech:xsd:pain.008.001.02",
@@ -414,17 +475,17 @@ class SEPAPaymentBordereau(Document):
 		grp_hdr = etree.SubElement(cstmr_drct_dbt_initn, "GrpHdr")
 		etree.SubElement(grp_hdr, "MsgId").text = self.name
 		etree.SubElement(grp_hdr, "CreDtTm").text = now_datetime().strftime("%Y-%m-%dT%H:%M:%S")
-		etree.SubElement(grp_hdr, "NbOfTxs").text = str(len(self.lines))
+		etree.SubElement(grp_hdr, "NbOfTxs").text = str(self.get_sepa_transaction_count())
 		etree.SubElement(grp_hdr, "CtrlSum").text = f"{self.total_amount:.2f}"
 		initg_pty = etree.SubElement(grp_hdr, "InitgPty")
 		etree.SubElement(initg_pty, "Nm").text = self.company
 
 		# One PmtInf per (mandate_type, sequence_type) group
-		for (mandate_type, sequence_type), group_lines in groups.items():
+		for (mandate_type, sequence_type), group_lines, suffix in ordered_groups:
 			group_total = sum(flt(line.amount) for line, _ in group_lines)
 
 			pmt_inf = etree.SubElement(cstmr_drct_dbt_initn, "PmtInf")
-			etree.SubElement(pmt_inf, "PmtInfId").text = f"{self.name}-{mandate_type}-{sequence_type}"
+			etree.SubElement(pmt_inf, "PmtInfId").text = f"{self.name}-{mandate_type}-{sequence_type}{suffix}"
 			etree.SubElement(pmt_inf, "PmtMtd").text = "DD"
 			etree.SubElement(pmt_inf, "NbOfTxs").text = str(len(group_lines))
 			etree.SubElement(pmt_inf, "CtrlSum").text = f"{group_total:.2f}"
@@ -534,7 +595,7 @@ class SEPAPaymentBordereau(Document):
 		cre_dt_tm = etree.SubElement(grp_hdr, "CreDtTm")
 		cre_dt_tm.text = now_datetime().strftime("%Y-%m-%dT%H:%M:%S")
 		nb_of_txs = etree.SubElement(grp_hdr, "NbOfTxs")
-		nb_of_txs.text = str(len(self.lines))
+		nb_of_txs.text = str(self.get_sepa_transaction_count())
 		ctrl_sum = etree.SubElement(grp_hdr, "CtrlSum")
 		ctrl_sum.text = f"{self.total_amount:.2f}"
 
@@ -577,8 +638,8 @@ class SEPAPaymentBordereau(Document):
 		bic = etree.SubElement(fin_instn_id, "BIC")
 		bic.text = bank_account.swift_number
 
-		# Credit Transfer Transaction Information for each line
-		for line in self.lines:
+		# Credit Transfer Transaction Information: invoice lines first, manual lines at the end
+		for line in list(self.lines or []) + list(self.get_manual_lines()):
 			# Get supplier bank account
 			supplier_bank_account = frappe.db.get_value(
 				"Bank Account",
@@ -645,6 +706,72 @@ class SEPAPaymentBordereau(Document):
 			)
 
 		return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8")
+
+	def _ordered_pain_008_groups(self):
+		"""Group debit lines by mandate type/sequence, invoice lines first then manuals."""
+		ordered = []
+		for lines, suffix in ((self.lines or [], ""), (self.get_manual_lines(), "-MANUAL")):
+			groups = {}
+			for line in lines:
+				if not line.mandate:
+					frappe.throw(_("SEPA Mandate is required for debit payments"))
+				mandate = frappe.get_doc("SEPA Mandate", line.mandate)
+				key = (mandate.mandate_type, mandate.sequence_type)
+				groups.setdefault(key, []).append((line, mandate))
+			for key, group_lines in groups.items():
+				ordered.append((key, group_lines, suffix))
+		return ordered
+
+	def create_manual_line_payment_entries(self):
+		"""Create unallocated payment entries for manual lines when the bordereau is closed."""
+		from erpnext_france.regional.france.sepa_utils import (
+			create_sepa_bank_transaction,
+			create_sepa_manual_line_payment_entry,
+		)
+
+		if self.status != "Closed":
+			return
+
+		gl_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
+		if not gl_account and self.get_manual_lines():
+			frappe.throw(_("Please link a GL Account to the Bank Account {0}").format(self.bank_account))
+
+		for line in self.get_manual_lines():
+			if line.payment_entry:
+				existing_status = frappe.db.get_value("Payment Entry", line.payment_entry, "docstatus")
+				if existing_status == 1:
+					continue
+
+			pe_name = create_sepa_manual_line_payment_entry(self, line, gl_account)
+			frappe.db.set_value(
+				"SEPA Payment Bordereau Manual Line",
+				line.name,
+				"payment_entry",
+				pe_name,
+				update_modified=False,
+			)
+			line.payment_entry = pe_name
+
+			try:
+				create_sepa_bank_transaction(pe_name, self, line)
+			except Exception:
+				frappe.log_error(
+					title=_("SEPA Bank Transaction Creation Error"), message=frappe.get_traceback()
+				)
+
+	@frappe.whitelist()
+	def close_bordereau(self):
+		"""Close the bordereau and create payment entries for manual lines."""
+		if self.status not in ["Sent", "Exported", "Partial Rejections"]:
+			frappe.throw(_("Only sent or exported bordereaux can be closed"))
+
+		pending_lines = [line for line in (self.lines or []) if line.status == "Pending"]
+		if pending_lines:
+			frappe.throw(_("Please accept or reject pending invoice lines before closing"))
+
+		self.status = "Closed"
+		self.save()
+		frappe.msgprint(_("Bordereau closed successfully"))
 
 	@frappe.whitelist()
 	def mark_as_sent(self):

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -95,11 +95,11 @@ class SEPAPaymentBordereau(Document):
 
 		sync_invoices_sepa_bordereau_links(invoices_to_sync)
 
-		# Update overall bordereau status if needed
+		# Update overall bordereau status if needed (read from DB: children are already written)
 		if status_changed_lines:
 			from erpnext_france.regional.france.sepa_utils import get_bordereau_line_statuses
 
-			statuses = get_bordereau_line_statuses(self)
+			statuses = get_bordereau_line_statuses(self.name)
 			new_status = self.status
 			if statuses and all(status == "Accepted" for status in statuses):
 				new_status = "Closed"
@@ -818,6 +818,7 @@ class SEPAPaymentBordereau(Document):
 					"Accepted",
 					update_modified=False,
 				)
+				line.status = "Accepted"
 				sync_invoice_sepa_bordereau_link(line.invoice, line.invoice_type)
 				results["success"].append({"name": line.name, "invoice": line.invoice})
 			except Exception as e:
@@ -866,6 +867,7 @@ class SEPAPaymentBordereau(Document):
 					"Accepted",
 					update_modified=False,
 				)
+				line.status = "Accepted"
 				results["success"].append({"name": line.name, "invoice": label})
 			except Exception as e:
 				frappe.db.rollback(save_point=savepoint)

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -69,6 +69,7 @@ class SEPAPaymentBordereau(Document):
 		if not self.is_new() and self.get_doc_before_save():
 			old_doc = self.get_doc_before_save()
 			old_statuses = {d.name: d.status for d in old_doc.lines}
+			old_manual_statuses = {d.name: d.status for d in (old_doc.get("manual_lines") or [])}
 			invoices_to_sync.update(
 				(line.invoice, line.invoice_type) for line in old_doc.lines if line.invoice
 			)
@@ -80,26 +81,35 @@ class SEPAPaymentBordereau(Document):
 					reconcile_sepa_line_on_status_change(self, line, line.status)
 					status_changed_lines = True
 
+			for line in self.get_manual_lines():
+				old_status = old_manual_statuses.get(line.name)
+				if line.status != old_status and line.status in ["Accepted", "Rejected"]:
+					from erpnext_france.regional.france.sepa_utils import (
+						reconcile_sepa_manual_line_on_status_change,
+					)
+
+					reconcile_sepa_manual_line_on_status_change(self, line, line.status)
+					status_changed_lines = True
+
 		from erpnext_france.regional.france.sepa_utils import sync_invoices_sepa_bordereau_links
 
 		sync_invoices_sepa_bordereau_links(invoices_to_sync)
 
 		# Update overall bordereau status if needed
-		if status_changed_lines and self.lines:
-			statuses = [line.status for line in self.lines]
+		if status_changed_lines:
+			from erpnext_france.regional.france.sepa_utils import get_bordereau_line_statuses
+
+			statuses = get_bordereau_line_statuses(self)
 			new_status = self.status
-			if all(status == "Accepted" for status in statuses):
+			if statuses and all(status == "Accepted" for status in statuses):
 				new_status = "Closed"
 			elif "Accepted" in statuses and "Rejected" in statuses:
 				new_status = "Partial Rejections"
-			elif all(status == "Rejected" for status in statuses):
+			elif statuses and all(status == "Rejected" for status in statuses):
 				new_status = "Exported"
 
 			if new_status != self.status:
 				self.db_set("status", new_status)
-
-		if self.status == "Closed":
-			self.create_manual_line_payment_entries()
 
 	def get_manual_lines(self):
 		return self.get("manual_lines") or []
@@ -485,7 +495,9 @@ class SEPAPaymentBordereau(Document):
 			group_total = sum(flt(line.amount) for line, _ in group_lines)
 
 			pmt_inf = etree.SubElement(cstmr_drct_dbt_initn, "PmtInf")
-			etree.SubElement(pmt_inf, "PmtInfId").text = f"{self.name}-{mandate_type}-{sequence_type}{suffix}"
+			etree.SubElement(pmt_inf, "PmtInfId").text = self._pain_008_pmt_inf_id(
+				mandate_type, sequence_type, suffix
+			)
 			etree.SubElement(pmt_inf, "PmtMtd").text = "DD"
 			etree.SubElement(pmt_inf, "NbOfTxs").text = str(len(group_lines))
 			etree.SubElement(pmt_inf, "CtrlSum").text = f"{group_total:.2f}"
@@ -707,10 +719,16 @@ class SEPAPaymentBordereau(Document):
 
 		return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="UTF-8")
 
+	def _pain_008_pmt_inf_id(self, mandate_type, sequence_type, suffix=""):
+		"""PmtInfId must be unique in the file and at most 35 characters (ISO 20022)."""
+		tail = f"-{mandate_type}-{sequence_type}{suffix}"
+		prefix = (self.name or "")[: max(1, 35 - len(tail))]
+		return f"{prefix}{tail}"[:35]
+
 	def _ordered_pain_008_groups(self):
 		"""Group debit lines by mandate type/sequence, invoice lines first then manuals."""
 		ordered = []
-		for lines, suffix in ((self.lines or [], ""), (self.get_manual_lines(), "-MANUAL")):
+		for lines, suffix in ((self.lines or [], ""), (self.get_manual_lines(), "-M")):
 			groups = {}
 			for line in lines:
 				if not line.mandate:
@@ -721,57 +739,6 @@ class SEPAPaymentBordereau(Document):
 			for key, group_lines in groups.items():
 				ordered.append((key, group_lines, suffix))
 		return ordered
-
-	def create_manual_line_payment_entries(self):
-		"""Create unallocated payment entries for manual lines when the bordereau is closed."""
-		from erpnext_france.regional.france.sepa_utils import (
-			create_sepa_bank_transaction,
-			create_sepa_manual_line_payment_entry,
-		)
-
-		if self.status != "Closed":
-			return
-
-		gl_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
-		if not gl_account and self.get_manual_lines():
-			frappe.throw(_("Please link a GL Account to the Bank Account {0}").format(self.bank_account))
-
-		for line in self.get_manual_lines():
-			if line.payment_entry:
-				existing_status = frappe.db.get_value("Payment Entry", line.payment_entry, "docstatus")
-				if existing_status == 1:
-					continue
-
-			pe_name = create_sepa_manual_line_payment_entry(self, line, gl_account)
-			frappe.db.set_value(
-				"SEPA Payment Bordereau Manual Line",
-				line.name,
-				"payment_entry",
-				pe_name,
-				update_modified=False,
-			)
-			line.payment_entry = pe_name
-
-			try:
-				create_sepa_bank_transaction(pe_name, self, line)
-			except Exception:
-				frappe.log_error(
-					title=_("SEPA Bank Transaction Creation Error"), message=frappe.get_traceback()
-				)
-
-	@frappe.whitelist()
-	def close_bordereau(self):
-		"""Close the bordereau and create payment entries for manual lines."""
-		if self.status not in ["Sent", "Exported", "Partial Rejections"]:
-			frappe.throw(_("Only sent or exported bordereaux can be closed"))
-
-		pending_lines = [line for line in (self.lines or []) if line.status == "Pending"]
-		if pending_lines:
-			frappe.throw(_("Please accept or reject pending invoice lines before closing"))
-
-		self.status = "Closed"
-		self.save()
-		frappe.msgprint(_("Bordereau closed successfully"))
 
 	@frappe.whitelist()
 	def mark_as_sent(self):
@@ -796,6 +763,7 @@ class SEPAPaymentBordereau(Document):
 
 		from erpnext_france.regional.france.sepa_utils import (
 			reconcile_sepa_line_on_status_change,
+			reconcile_sepa_manual_line_on_status_change,
 			sync_invoice_sepa_bordereau_link,
 			update_bordereau_status,
 		)
@@ -861,6 +829,47 @@ class SEPAPaymentBordereau(Document):
 						"reason": str(e),
 					}
 				)
+
+		for line in self.get_manual_lines():
+			if line.name not in line_names_set:
+				continue
+
+			label = line.document_ref or line.party
+			if line.status == "Accepted":
+				results["skipped"].append(
+					{"name": line.name, "invoice": label, "reason": _("Already accepted")}
+				)
+				continue
+
+			if line.payment_entry:
+				pe_docstatus = frappe.db.get_value("Payment Entry", line.payment_entry, "docstatus")
+				if pe_docstatus == 1:
+					results["skipped"].append(
+						{"name": line.name, "invoice": label, "reason": _("Payment Entry already linked")}
+					)
+					continue
+
+			if line.status != "Pending":
+				results["skipped"].append(
+					{"name": line.name, "invoice": label, "reason": _("Line is not pending")}
+				)
+				continue
+
+			savepoint = f"sepa_accept_manual_{line.name}"
+			try:
+				frappe.db.savepoint(savepoint)
+				reconcile_sepa_manual_line_on_status_change(self, line, "Accepted", silent=True)
+				frappe.db.set_value(
+					"SEPA Payment Bordereau Manual Line",
+					line.name,
+					"status",
+					"Accepted",
+					update_modified=False,
+				)
+				results["success"].append({"name": line.name, "invoice": label})
+			except Exception as e:
+				frappe.db.rollback(save_point=savepoint)
+				results["failed"].append({"name": line.name, "invoice": label, "reason": str(e)})
 
 		update_bordereau_status(self.name)
 

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau/sepa_payment_bordereau.py
@@ -65,10 +65,11 @@ class SEPAPaymentBordereau(Document):
 	def on_update(self):
 		status_changed_lines = False
 		invoices_to_sync = {(line.invoice, line.invoice_type) for line in self.lines if line.invoice}
-		old_doc = None if self.is_new() else self.get_doc_before_save()
 
-		if old_doc:
+		if not self.is_new() and self.get_doc_before_save():
+			old_doc = self.get_doc_before_save()
 			old_statuses = {d.name: d.status for d in old_doc.lines}
+			old_manual_statuses = {d.name: d.status for d in (old_doc.get("manual_lines") or [])}
 			invoices_to_sync.update(
 				(line.invoice, line.invoice_type) for line in old_doc.lines if line.invoice
 			)
@@ -80,25 +81,17 @@ class SEPAPaymentBordereau(Document):
 					reconcile_sepa_line_on_status_change(self, line, line.status)
 					status_changed_lines = True
 
-		from erpnext_france.regional.france.sepa_utils import (
-			reconcile_sepa_manual_line_on_status_change,
-			sync_invoices_sepa_bordereau_links,
-		)
+			for line in self.get_manual_lines():
+				old_status = old_manual_statuses.get(line.name)
+				if line.status != old_status and line.status in ["Accepted", "Rejected"]:
+					from erpnext_france.regional.france.sepa_utils import (
+						reconcile_sepa_manual_line_on_status_change,
+					)
 
-		old_manual_statuses = {}
-		if old_doc:
-			old_manual_statuses = {d.name: d.status for d in (old_doc.get("manual_lines") or [])}
+					reconcile_sepa_manual_line_on_status_change(self, line, line.status)
+					status_changed_lines = True
 
-		# Create missing Payment Entries for Accepted/Rejected manual lines, even if
-		# the status change was not detected (grid edit, catch-up after a failed save).
-		for line in self.get_manual_lines():
-			if line.status not in ("Accepted", "Rejected"):
-				continue
-			old_status = old_manual_statuses.get(line.name)
-			if line.status == old_status and self._manual_line_has_submitted_payment_entry(line):
-				continue
-			reconcile_sepa_manual_line_on_status_change(self, line, line.status)
-			status_changed_lines = True
+		from erpnext_france.regional.france.sepa_utils import sync_invoices_sepa_bordereau_links
 
 		sync_invoices_sepa_bordereau_links(invoices_to_sync)
 
@@ -117,13 +110,6 @@ class SEPAPaymentBordereau(Document):
 
 			if new_status != self.status:
 				self.db_set("status", new_status)
-
-	@staticmethod
-	def _manual_line_has_submitted_payment_entry(line):
-		payment_entry = line.get("payment_entry")
-		if not payment_entry:
-			return False
-		return frappe.db.get_value("Payment Entry", payment_entry, "docstatus") == 1
 
 	def get_manual_lines(self):
 		return self.get("manual_lines") or []
@@ -880,13 +866,7 @@ class SEPAPaymentBordereau(Document):
 					"Accepted",
 					update_modified=False,
 				)
-				results["success"].append(
-					{
-						"name": line.name,
-						"invoice": label,
-						"payment_entry": line.payment_entry,
-					}
-				)
+				results["success"].append({"name": line.name, "invoice": label})
 			except Exception as e:
 				frappe.db.rollback(save_point=savepoint)
 				results["failed"].append({"name": line.name, "invoice": label, "reason": str(e)})

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
@@ -1,0 +1,82 @@
+{
+ "actions": [],
+ "creation": "2026-08-26 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "document_ref",
+  "party_type",
+  "party",
+  "amount",
+  "mandate",
+  "end_to_end_id",
+  "payment_entry"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_ref",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Document Reference",
+   "reqd": 1
+  },
+  {
+   "default": "Customer",
+   "fieldname": "party_type",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Party Type",
+   "options": "Customer\nSupplier",
+   "reqd": 1
+  },
+  {
+   "fieldname": "party",
+   "fieldtype": "Dynamic Link",
+   "in_list_view": 1,
+   "label": "Party",
+   "options": "party_type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:parent.payment_type=='Debit'",
+   "fieldname": "mandate",
+   "fieldtype": "Link",
+   "label": "SEPA Mandate",
+   "options": "SEPA Mandate"
+  },
+  {
+   "fieldname": "end_to_end_id",
+   "fieldtype": "Data",
+   "label": "End-to-End ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payment_entry",
+   "fieldtype": "Link",
+   "label": "Payment Entry",
+   "no_copy": 1,
+   "options": "Payment Entry",
+   "read_only": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-26 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "ERPNext France",
+ "name": "SEPA Payment Bordereau Manual Line",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
@@ -62,6 +62,7 @@
   {
    "fieldname": "payment_entry",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Payment Entry",
    "no_copy": 1,
    "options": "Payment Entry",
@@ -79,7 +80,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-08-26 12:15:00.000000",
+ "modified": "2026-08-26 12:40:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau Manual Line",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.json
@@ -11,7 +11,8 @@
   "amount",
   "mandate",
   "end_to_end_id",
-  "payment_entry"
+  "payment_entry",
+  "status"
  ],
  "fields": [
   {
@@ -65,11 +66,20 @@
    "no_copy": 1,
    "options": "Payment Entry",
    "read_only": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Pending\nAccepted\nRejected",
+   "reqd": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-08-26 00:00:00.000000",
+ "modified": "2026-08-26 12:15:00.000000",
  "modified_by": "Administrator",
  "module": "ERPNext France",
  "name": "SEPA Payment Bordereau Manual Line",

--- a/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.py
+++ b/erpnext_france/erpnext_france/doctype/sepa_payment_bordereau_manual_line/sepa_payment_bordereau_manual_line.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Scopen and Contributors
+# See license.txt
+
+from frappe.model.document import Document
+
+
+class SEPAPaymentBordereauManualLine(Document):
+	pass

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -664,14 +664,20 @@ def add_pain_remittance_info(transaction_element, remittance_info):
 	etree.SubElement(rmt_inf, "Ustrd").text = remittance_info
 
 
+def get_bordereau_line_statuses(bordereau):
+	"""Return statuses of invoice lines and manual lines."""
+	statuses = [line.status for line in (bordereau.lines or [])]
+	statuses.extend(line.status for line in (bordereau.get("manual_lines") or []))
+	return statuses
+
+
 def update_bordereau_status(bordereau_name):
-	"""Update bordereau status based on line statuses"""
+	"""Update bordereau status based on invoice and manual line statuses"""
 	bordereau = frappe.get_doc("SEPA Payment Bordereau", bordereau_name)
 
-	if not bordereau.lines:
+	statuses = get_bordereau_line_statuses(bordereau)
+	if not statuses:
 		return
-
-	statuses = [line.status for line in bordereau.lines]
 
 	# If all accepted, mark as Closed
 	if all(status == "Accepted" for status in statuses):
@@ -857,6 +863,67 @@ def create_sepa_manual_line_payment_entry(bordereau, line, gl_account):
 	payment_entry.submit()
 
 	return payment_entry.name
+
+
+def reconcile_sepa_manual_line_on_status_change(bordereau, line, new_status, silent=False):
+	if getattr(line, "_reconciled_status_change", False):
+		return
+
+	existing_pe = line.get("payment_entry")
+	existing_docstatus = None
+	if existing_pe and frappe.db.exists("Payment Entry", existing_pe):
+		existing_docstatus = frappe.db.get_value("Payment Entry", existing_pe, "docstatus")
+
+	if existing_docstatus == 1:
+		line._reconciled_status_change = True
+		return
+
+	if existing_docstatus == 2:
+		if new_status == "Rejected":
+			line._reconciled_status_change = True
+			return
+		line.payment_entry = None
+		frappe.db.set_value(
+			"SEPA Payment Bordereau Manual Line",
+			line.name,
+			"payment_entry",
+			None,
+			update_modified=False,
+		)
+
+	gl_account = frappe.db.get_value("Bank Account", bordereau.bank_account, "account")
+	if not gl_account:
+		frappe.throw(_("Please link a GL Account to the Bank Account {0}").format(bordereau.bank_account))
+
+	if new_status in ("Accepted", "Rejected"):
+		pe_name = create_sepa_manual_line_payment_entry(bordereau, line, gl_account)
+		line.payment_entry = pe_name
+		frappe.db.set_value(
+			"SEPA Payment Bordereau Manual Line",
+			line.name,
+			"payment_entry",
+			pe_name,
+			update_modified=False,
+		)
+		if new_status == "Rejected":
+			frappe.get_doc("Payment Entry", pe_name).cancel()
+			if not silent:
+				frappe.msgprint(
+					_("Payment Entry {0} created and cancelled for rejected SEPA line {1} (+ and -)").format(
+						pe_name, line.name
+					)
+				)
+		else:
+			if not silent:
+				frappe.msgprint(_("Payment Entry {0} created for SEPA line {1}").format(pe_name, line.name))
+			try:
+				create_sepa_bank_transaction(pe_name, bordereau, line)
+			except Exception:
+				frappe.log_error(
+					title=_("SEPA Bank Transaction Creation Error"), message=frappe.get_traceback()
+				)
+
+	line._reconciled_status_change = True
 
 
 def _get_sepa_line_invoice_outstanding(line):

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -622,21 +622,33 @@ def add_invoices_to_sepa_bordereau_bulk(invoice_names: list | str, invoice_type:
 
 
 def get_sepa_line_invoice_reference(line):
-	"""Return the invoice reference shown to customers/suppliers on bank statements."""
-	invoice_type = getattr(line, "invoice_type", None) or (
-		"Sales Invoice" if line.party_type == "Customer" else "Purchase Invoice"
+	"""Return the document reference shown to customers/suppliers on bank statements."""
+	document_ref = _sepa_line_value(line, "document_ref")
+	invoice = _sepa_line_value(line, "invoice")
+	if document_ref and not invoice:
+		return document_ref
+
+	invoice_type = _sepa_line_value(line, "invoice_type") or (
+		"Sales Invoice"
+		if _sepa_line_value(line, "party_type") == "Customer"
+		else "Purchase Invoice"
 	)
 
-	if invoice_type == "Purchase Invoice":
-		bill_no = frappe.db.get_value("Purchase Invoice", line.invoice, "bill_no")
+	if invoice_type == "Purchase Invoice" and invoice:
+		bill_no = frappe.db.get_value("Purchase Invoice", invoice, "bill_no")
 		if bill_no:
 			return bill_no
 
-	return line.invoice
+	return invoice
 
 
 def get_sepa_line_remittance_info(line):
 	"""Build SEPA unstructured remittance text (max 140 chars)."""
+	document_ref = _sepa_line_value(line, "document_ref")
+	invoice = _sepa_line_value(line, "invoice")
+	if document_ref and not invoice:
+		return document_ref[:140]
+
 	invoice_ref = get_sepa_line_invoice_reference(line)
 	return _("Invoice {0}").format(invoice_ref)[:140]
 
@@ -687,17 +699,34 @@ def get_sepa_payment_type(bordereau):
 	return "Receive" if bordereau.payment_type == "Debit" else "Pay"
 
 
-def get_sepa_party_account(line):
-	invoice_type = _sepa_line_value(line, "invoice_type") or (
-		"Sales Invoice" if _sepa_line_value(line, "party_type") == "Customer" else "Purchase Invoice"
+def get_sepa_party_account(line, company=None):
+	invoice = _sepa_line_value(line, "invoice")
+	if invoice:
+		invoice_type = _sepa_line_value(line, "invoice_type") or (
+			"Sales Invoice" if _sepa_line_value(line, "party_type") == "Customer" else "Purchase Invoice"
+		)
+		account_field = "debit_to" if invoice_type == "Sales Invoice" else "credit_to"
+		return frappe.db.get_value(invoice_type, invoice, account_field)
+
+	from erpnext.accounts.party import get_party_account
+
+	return get_party_account(
+		_sepa_line_value(line, "party_type"),
+		_sepa_line_value(line, "party"),
+		company,
 	)
-	account_field = "debit_to" if invoice_type == "Sales Invoice" else "credit_to"
-	return frappe.db.get_value(invoice_type, _sepa_line_value(line, "invoice"), account_field)
 
 
 def get_sepa_payment_entry_account_fields(bordereau, line, gl_account):
 	payment_type = get_sepa_payment_type(bordereau)
-	party_account = get_sepa_party_account(line)
+	party_account = get_sepa_party_account(line, bordereau.company)
+
+	if not party_account:
+		frappe.throw(
+			_("No party account found for {0} {1}").format(
+				_sepa_line_value(line, "party_type"), _sepa_line_value(line, "party")
+			)
+		)
 
 	if payment_type == "Pay":
 		return payment_type, {"paid_from": gl_account, "paid_to": party_account}
@@ -790,6 +819,42 @@ def create_sepa_payment_entry(bordereau, line, gl_account):
 		mandate = frappe.get_doc("SEPA Mandate", line.mandate)
 		if mandate.sequence_type == "FRST":
 			mandate.update_to_recurring()
+
+	return payment_entry.name
+
+
+def create_sepa_manual_line_payment_entry(bordereau, line, gl_account):
+	"""Create an unallocated Payment Entry (advance) for a manual SEPA line."""
+	existing_pe = line.get("payment_entry")
+	if existing_pe and frappe.db.exists("Payment Entry", existing_pe):
+		if frappe.db.get_value("Payment Entry", existing_pe, "docstatus") == 1:
+			return existing_pe
+		line.payment_entry = None
+
+	document_ref = _sepa_line_value(line, "document_ref") or bordereau.name
+	payment_type, account_fields = get_sepa_payment_entry_account_fields(bordereau, line, gl_account)
+
+	pe_data = {
+		"doctype": "Payment Entry",
+		"payment_type": payment_type,
+		"company": bordereau.company,
+		"party_type": line.party_type,
+		"party": line.party,
+		"paid_amount": line.amount,
+		"received_amount": line.amount,
+		"posting_date": bordereau.execution_date,
+		"reference_no": document_ref,
+		"reference_date": bordereau.execution_date,
+		"remarks": document_ref,
+		"bank_account": bordereau.bank_account,
+		**account_fields,
+	}
+	if frappe.db.has_column("Payment Entry", "sepa_payment_bordereau"):
+		pe_data["sepa_payment_bordereau"] = bordereau.name
+
+	payment_entry = frappe.get_doc(pe_data)
+	payment_entry.insert()
+	payment_entry.submit()
 
 	return payment_entry.name
 

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -837,31 +837,42 @@ def create_sepa_manual_line_payment_entry(bordereau, line, gl_account):
 			return existing_pe
 		line.payment_entry = None
 
+	expected_party_type = "Supplier" if bordereau.payment_type == "Credit" else "Customer"
+	if isinstance(line, dict):
+		line["party_type"] = expected_party_type
+	else:
+		line.party_type = expected_party_type
+
+	party = _sepa_line_value(line, "party")
+	amount = flt(_sepa_line_value(line, "amount"))
 	document_ref = _sepa_line_value(line, "document_ref") or bordereau.name
 	if frappe.db.has_column("Payment Entry", "sepa_payment_bordereau"):
 		linked_pe = frappe.db.exists(
 			"Payment Entry",
 			{
 				"sepa_payment_bordereau": bordereau.name,
-				"party": _sepa_line_value(line, "party"),
+				"party": party,
 				"reference_no": document_ref,
 				"docstatus": 1,
-				"paid_amount": line.amount,
+				"paid_amount": amount,
 			},
 		)
 		if linked_pe:
 			return linked_pe
 
 	payment_type, account_fields = get_sepa_payment_entry_account_fields(bordereau, line, gl_account)
+	cost_center = frappe.db.get_value("Company", bordereau.company, "cost_center")
 
 	pe_data = {
 		"doctype": "Payment Entry",
 		"payment_type": payment_type,
 		"company": bordereau.company,
-		"party_type": line.party_type,
-		"party": line.party,
-		"paid_amount": line.amount,
-		"received_amount": line.amount,
+		"party_type": expected_party_type,
+		"party": party,
+		"paid_amount": amount,
+		"received_amount": amount,
+		"source_exchange_rate": 1,
+		"target_exchange_rate": 1,
 		"posting_date": bordereau.execution_date,
 		"reference_no": document_ref,
 		"reference_date": bordereau.execution_date,
@@ -869,12 +880,21 @@ def create_sepa_manual_line_payment_entry(bordereau, line, gl_account):
 		"bank_account": bordereau.bank_account,
 		**account_fields,
 	}
+	if cost_center:
+		pe_data["cost_center"] = cost_center
 	if frappe.db.has_column("Payment Entry", "sepa_payment_bordereau"):
 		pe_data["sepa_payment_bordereau"] = bordereau.name
 
-	payment_entry = frappe.get_doc(pe_data)
-	payment_entry.insert()
-	payment_entry.submit()
+	try:
+		payment_entry = frappe.get_doc(pe_data)
+		payment_entry.flags.ignore_permissions = True
+		payment_entry.insert()
+		payment_entry.submit()
+	except Exception as e:
+		frappe.log_error(title=_("SEPA Manual Line Payment Entry Error"), message=frappe.get_traceback())
+		frappe.throw(
+			_("Could not create Payment Entry for {0} (ref {1}): {2}").format(party, document_ref, str(e))
+		)
 
 	return payment_entry.name
 

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -838,6 +838,20 @@ def create_sepa_manual_line_payment_entry(bordereau, line, gl_account):
 		line.payment_entry = None
 
 	document_ref = _sepa_line_value(line, "document_ref") or bordereau.name
+	if frappe.db.has_column("Payment Entry", "sepa_payment_bordereau"):
+		linked_pe = frappe.db.exists(
+			"Payment Entry",
+			{
+				"sepa_payment_bordereau": bordereau.name,
+				"party": _sepa_line_value(line, "party"),
+				"reference_no": document_ref,
+				"docstatus": 1,
+				"paid_amount": line.amount,
+			},
+		)
+		if linked_pe:
+			return linked_pe
+
 	payment_type, account_fields = get_sepa_payment_entry_account_fields(bordereau, line, gl_account)
 
 	pe_data = {

--- a/erpnext_france/regional/france/sepa_utils.py
+++ b/erpnext_france/regional/france/sepa_utils.py
@@ -665,34 +665,44 @@ def add_pain_remittance_info(transaction_element, remittance_info):
 
 
 def get_bordereau_line_statuses(bordereau):
-	"""Return statuses of invoice lines and manual lines."""
-	statuses = [line.status for line in (bordereau.lines or [])]
-	statuses.extend(line.status for line in (bordereau.get("manual_lines") or []))
+	"""Return invoice and manual line statuses from the database.
+
+	Accept Selection updates child rows with db.set_value, so in-memory / cached
+	parent documents often still show Pending and would skip auto-close.
+	"""
+	name = bordereau if isinstance(bordereau, str) else bordereau.name
+	statuses = frappe.get_all(
+		"SEPA Payment Bordereau Line",
+		filters={"parent": name},
+		pluck="status",
+	)
+	statuses.extend(
+		frappe.get_all(
+			"SEPA Payment Bordereau Manual Line",
+			filters={"parent": name},
+			pluck="status",
+		)
+	)
 	return statuses
 
 
 def update_bordereau_status(bordereau_name):
-	"""Update bordereau status based on invoice and manual line statuses"""
-	bordereau = frappe.get_doc("SEPA Payment Bordereau", bordereau_name)
-
-	statuses = get_bordereau_line_statuses(bordereau)
+	"""Update bordereau status based on invoice and manual line statuses."""
+	statuses = get_bordereau_line_statuses(bordereau_name)
 	if not statuses:
 		return
 
-	# If all accepted, mark as Closed
 	if all(status == "Accepted" for status in statuses):
-		bordereau.status = "Closed"
-		bordereau.save()
-
-	# If some accepted and some rejected, mark as Partial Rejections
+		new_status = "Closed"
 	elif "Accepted" in statuses and "Rejected" in statuses:
-		bordereau.status = "Partial Rejections"
-		bordereau.save()
-
-	# If all rejected, keep as Exported (can be re-sent)
+		new_status = "Partial Rejections"
 	elif all(status == "Rejected" for status in statuses):
-		bordereau.status = "Exported"
-		bordereau.save()
+		new_status = "Exported"
+	else:
+		return
+
+	if frappe.db.get_value("SEPA Payment Bordereau", bordereau_name, "status") != new_status:
+		frappe.db.set_value("SEPA Payment Bordereau", bordereau_name, "status", new_status)
 
 
 def _sepa_line_value(line, field):

--- a/erpnext_france/translations/fr.csv
+++ b/erpnext_france/translations/fr.csv
@@ -667,6 +667,22 @@ Payment Entry {0} created and cancelled for rejected SEPA line {1} (+ and -),L'�
 SEPA Mandate,Mandat SEPA
 SEPA Payment Bordereau,Bordereau de Paiement SEPA
 SEPA Payment Bordereau Line,Ligne de Bordereau de Paiement SEPA
+SEPA Payment Bordereau Manual Line,Ligne manuelle de Bordereau de Paiement SEPA
+Manual Payment Lines,Lignes manuelles
+Document Reference,Ref du document
+Close Bordereau,Clôturer le bordereau
+Closing bordereau...,Clôture du bordereau...
+Bordereau closed successfully,Bordereau clôturé avec succès
+Please add at least one payment line,Veuillez ajouter au moins une ligne de paiement
+Manual row {0}: Party is required,Ligne manuelle {0} : le tiers est obligatoire
+Manual row {0}: Document Reference is required,Ligne manuelle {0} : la ref du document est obligatoire
+Manual row {0}: Supplier {1} does not have a default bank account,Ligne manuelle {0} : le fournisseur {1} n'a pas de compte bancaire par défaut
+Manual row {0}: SEPA Mandate is required for debit payments,Ligne manuelle {0} : un mandat SEPA est obligatoire pour les prélèvements
+Manual row {0}: Amount must be greater than zero,Ligne manuelle {0} : le montant doit être supérieur à zéro
+Manual row {0}: SEPA Mandate must be active,Ligne manuelle {0} : le mandat SEPA doit être actif
+Only sent or exported bordereaux can be closed,Seuls les bordereaux envoyés ou exportés peuvent être clôturés
+Please accept or reject pending invoice lines before closing,Veuillez accepter ou rejeter les lignes de facture en attente avant de clôturer
+No party account found for {0} {1},Aucun compte de tiers trouvé pour {0} {1}
 SEPA Line Status,Statut ligne SEPA
 Payment Type,Type de paiement
 Debit,Prélèvement

--- a/erpnext_france/translations/fr.csv
+++ b/erpnext_france/translations/fr.csv
@@ -659,6 +659,8 @@ Account Code Length,Longueur du code comptable
 "If you set the value to 6 here, account '706' will appear as '706000' in exports","Si vous définissez la valeur à 6 ici, le compte '706' apparaîtra comme '706000' dans les exports"
 Leave Approver,Approbateur de note de frais,Department
 Payment Entry {0} created for SEPA line {1},L'écriture de paiement {0} a été créée pour la ligne SEPA {1}
+Could not create Payment Entry for {0} (ref {1}): {2},Impossible de créer l'écriture de paiement pour {0} (ref {1}) : {2}
+SEPA Manual Line Payment Entry Error,Erreur de création d'écriture pour une ligne manuelle SEPA
 Invoice {0},Facture {0}
 SEPA Bank Transaction Creation Error,Erreur de création de transaction bancaire SEPA
 Bank Transaction {0} created for SEPA line {1},La transaction bancaire {0} a été créée pour la ligne SEPA {1}


### PR DESCRIPTION
Add a child table for advances so suppliers or customers can be paid before the invoice exists, include those lines at the end of the SEPA XML, and create an unallocated payment entry on close.